### PR TITLE
Fixed google approval URL

### DIFF
--- a/Providers/GoogleAuthentication/GoogleAuthProvider.cs
+++ b/Providers/GoogleAuthentication/GoogleAuthProvider.cs
@@ -15,7 +15,7 @@ namespace CodeValue.SuiteValue.UI.Metro.GoogleAuthentication
     public class GoogleAuthProvider : IAuthProvider
     {
         private const string AuthorizationUrl = "https://accounts.google.com/o/oauth2/auth";
-        private const string ApprovalUrl = "https://accounts.google.com/o/oauth2/approval?";
+        private const string ApprovalUrl = "https://accounts.google.com/o/oauth2/approval";
         private const string UserInfoUrl = "https://www.googleapis.com/oauth2/v1/userinfo";
         private const string TokenUrl = "https://accounts.google.com/o/oauth2/token";
         private const string DefaultScope =


### PR DESCRIPTION
## Background

I'm not sure why, but my application, which uses `SuiteValue.UI.Metro` for logging users into Google, stopped working last week (I got multiple reports from diff users).

So I looked into the issue, try to go through the OAuth2 process manually, and I ended up landing on an URL that looked like this:

> https://accounts.google.com/o/oauth2/approval/v2/approvalnativeapp?auto=true&response=code%3D4%2FGcode goes here&approvalCode=4%2Fapproval code goes here

However, `SuiteValue.UI.Metro` expects the OAuth process to end up on a page with a URL like `https://accounts.google.com/o/oauth2/approval?`, optionally followed by 1 or more characters.

As you can see, there's no question mark `?` on the URL anymore.

## Fix

This PR fixes the issue by removing the `?` out of `GoogleAuthProvider.ApprovalURL`.

I've already fixed this in my app, tested it myself, pushed to the store, and got feedback from other users saying it's now fixed for them as well.